### PR TITLE
add open stf

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ TaaS stands for Test as a Service. Usually, TaaS provides us test platform like 
 - [compile-testing](https://github.com/google/compile-testing)
 - [screenshot-tests-for-android](https://github.com/facebook/screenshot-tests-for-android)
 - [Mobile-Security-Framework-MobSF](https://github.com/ajinabraham/Mobile-Security-Framework-MobSF)
+- [OpenSTF](https://github.com/openstf) (2.x support API to control devices remotely.)
 
 ## Documents
 


### PR DESCRIPTION
Add OpenSTF.

OpenSTF 1.x is just a device management tool. But 2.0 provides APIs to handle devices via API. It helps automated test like using Appium.

So, I add this tool in `other` .
(I will merge after a few days.)
