### PR TITLE
add droid test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Of course it sometimes includes google's official one.
 - [Monket Talk](https://www.cloudmonkeymobile.com/monkeytalk)
 - [Magneto](https://github.com/EverythingMe/magneto)
 
+### Helper
+- [DroidTestHelper](https://github.com/KazuCocoa/DroidTestHelper)
+
+
 ## Recorder
 
 - [appium-dot-app](https://github.com/appium/appium-dot-app)


### PR DESCRIPTION
This library have been used in my company for around a half year.

We can manage locale, animation scale and account manager via **broadcast receiver**. So, this helper application is used with Appium.
(This library is similar to `test-butler` I added before.)

What do you think whether I can merge this or not ?
